### PR TITLE
fix: bump jenkins version and bom to address CVEs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
+    - name: Set up JDK 1.11
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,5 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: '8'],
     [platform: 'linux', jdk: '11']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
     <name>ValidatingYamlParameter</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -32,7 +32,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
+                <artifactId>bom-2.361.x</artifactId>
                 <version>1742.vb_70478c1b_25f</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

dependabot required to bump some versions. This is to keep dependabot's workflow compatible.

Also, removed building requirements using java-8, at this point java-11 is the minimum requirement.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
