### PR TITLE
fix: upgrade snakeyaml to 2.0 and fix the SafeConstructor calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterDefinition.java
@@ -42,6 +42,7 @@ import org.kohsuke.stapler.verb.POST;
 import org.kohsuke.stapler.StaplerRequest;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.LoaderOptions;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -102,7 +103,9 @@ public class ValidatingYamlParameterDefinition extends ParameterDefinition{
 
     private static ValidationResult doCheckYaml(String value) {
         ValidationResult vres = new ValidationResult();
-        Yaml yaml = new Yaml(new SafeConstructor());
+        LoaderOptions options = new LoaderOptions();
+        SafeConstructor constructor = new SafeConstructor(options);
+        Yaml yaml = new Yaml(constructor);
         try {
             yaml.load(value);
             vres.setResult(true);

--- a/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterValue.java
@@ -35,6 +35,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.LoaderOptions;
 
 /**
  *
@@ -69,7 +70,9 @@ public class ValidatingYamlParameterValue extends StringParameterValue {
     }
 
     private boolean doCheckYaml(String value) {
-        Yaml yaml = new Yaml(new SafeConstructor());
+        LoaderOptions options = new LoaderOptions();
+        SafeConstructor constructor = new SafeConstructor(options);
+        Yaml yaml = new Yaml(constructor);
         try {
             yaml.load(value);
             return true;


### PR DESCRIPTION
Update snakeyaml dependency to 2.0 to address [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)
