### PR TITLE
fix: bump jenkins version requirement to prepare for hpi-5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,11 +57,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up JDK 1.17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+
     - name: Setup Maven
       uses: stCarolas/setup-maven@v5
       with:
         maven-version: '3.9.6'
-        
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -15,7 +15,13 @@ permissions:
 
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
-    with:
-      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.
+    steps:
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: '3.9.6'
+    - name: Run Security Scan
+      uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+      with:
+        java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+        # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,11 +16,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 1.11
+    - name: Set up JDK 1.17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
+        cache: 'maven'
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: '3.9.6'
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,5 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: '11'],
     [platform: 'linux', jdk: '17']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.1</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,7 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.479</jenkins.version>
     </properties>
     <name>ValidatingYamlParameter</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -59,11 +59,23 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+            <id>repo.jenkins-ci.org-snapshots</id>
+            <url>https://repo.jenkins-ci.org/snapshots/</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org-snapshots</id>
+            <url>https://repo.jenkins-ci.org/snapshots/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org-releases</id>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>


### PR DESCRIPTION
dependabot is pushing the upgrade of jenkins-plugins to 5.1, but there's a breaking change with jenkins version

### Testing done

CI

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
