### PR TITLE
Migrate legacy checkUrl to checkDependsOn (JENKINS-74507)

### DIFF
--- a/src/main/resources/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterDefinition/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterDefinition/index.jelly
@@ -32,7 +32,8 @@ THE SOFTWARE.
         <div name="parameter" description="${it.formattedDescription}">
             <input type="hidden" name="name" value="${it.name}" />
             <f:textarea codemirror-mode="yaml" name="value" value="${it.defaultValue}"
-                    checkUrl="'${rootURL}/descriptorByName/io.jenkins.plugins.validating_yaml_parameter.ValidatingYamlParameterDefinition/validate?value='+encodeURIComponent(this.value)" checkMethod="post" />
+                    checkUrl="descriptorByName/io.jenkins.plugins.validating_yaml_parameter.ValidatingYamlParameterDefinition/validate"
+                    checkDependsOn="value" checkMethod="post" />
         </div>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
## Summary
- Replaces the legacy JavaScript-style `checkUrl` expression in `index.jelly` with the modern `checkUrl` + `checkDependsOn` form, following the [Jenkins CSP migration guide](https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation).

Fixes #184 / JENKINS-74507.

## Test plan
- [x] `mvn clean verify` passes
- [x] `mvn hpi:run` — verified the parameter validation still works in the UI (invalid YAML shows the validation error, valid YAML clears it)