### PR TITLE
Remove unused syntaxHighlighting field

### DIFF
--- a/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/validating_yaml_parameter/ValidatingYamlParameterValue.java
@@ -42,7 +42,6 @@ import org.yaml.snakeyaml.LoaderOptions;
  */
 public class ValidatingYamlParameterValue extends StringParameterValue {
 
-    private boolean syntaxHighlighting;
     private String failedValidationMessage;
 
     @DataBoundConstructor


### PR DESCRIPTION
## Summary
- Removes the unused `private boolean syntaxHighlighting` field from `ValidatingYamlParameterValue`. It has no getter, no setter, no `@DataBoundSetter`, is never read or written anywhere in the codebase, and is not referenced from any Jelly view — pure dead code.

## Test plan
- [x] `mvn clean verify` passes
- [x] `grep -r "syntaxHighlighting" src/` returns no matches after the change